### PR TITLE
Add z3-solver dependency to plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -24,6 +24,12 @@
       "Windows": "Install `z3-solver` using pip: `pip install z3-solver`",
       "Linux": "Install `z3-solver` using pip: `pip install z3-solver`"
    },
+   "dependencies": {
+		"pip": ["z3-solver"],
+		"apt": [],
+		"installers": [],
+		"other": []
+	},
    "version": "0.2.2",
    "minimumbinaryninjaversion": 2100
 }


### PR DESCRIPTION
Installing with the binary ninja plugin manager should now install z3 if I'm understanding that correctly.