### PR TITLE
refactor: add target abstraction for os/arch

### DIFF
--- a/arch/arch_abstract.py
+++ b/arch/arch_abstract.py
@@ -49,6 +49,9 @@ class Arch(object):  # abstract class
     def execute_special_handler(self, disasm_str, sv):
         raise NotImplementedError
 
+    def normalize_reg_write(self, reg_name, value, dest_size_bytes):
+        return reg_name, value
+
     def is_synthetic_reg(self, reg_name):
         return False
 

--- a/arch/arch_x86_64.py
+++ b/arch/arch_x86_64.py
@@ -492,5 +492,22 @@ class x8664Arch(Arch):
         res = x8664Arch.sph.handle_instruction(disasm_str, sv)
         return res
 
+    def normalize_reg_write(self, reg_name, value, dest_size_bytes):
+        zero_extend_regs = {
+            'eax',  'ebx',  'ecx',  'edx',
+            'edi',  'esi',  'esp',  'ebp',
+            'r8d',  'r9d',  'r10d', 'r11d',
+            'r12d', 'r13d', 'r14d', 'r15d'
+        }
+        if reg_name in zero_extend_regs:
+            full_reg = ("r" + reg_name[1:]) if reg_name[0] == 'e' else reg_name[:-1]
+            full_size_bits = x8664Arch.REGS[full_reg]['size'] * 8
+            if value.size < full_size_bits:
+                value = value.ZeroExt(full_size_bits - value.size)
+            elif value.size > full_size_bits:
+                value = value.Extract(full_size_bits - 1, 0)
+            return full_reg, value
+        return reg_name, value
+
 
 Arch.fix_reg_addressess(x8664Arch)

--- a/models/linux_syscalls.py
+++ b/models/linux_syscalls.py
@@ -1,18 +1,14 @@
 from ..utility.expr_wrap_util import symbolic
 from ..utility.exceptions import ExitException, ModelError
-from ..expr import BVV, BVS
+from ..expr import BVV
 
 MAX_SYM_READ_WRITE = 100
 
 
 def read_handler(state):
-    fd_reg = state.os.get_syscall_parameter(1)
-    buf_reg = state.os.get_syscall_parameter(2)
-    count_reg = state.os.get_syscall_parameter(3)
-
-    fd = getattr(state.regs, fd_reg)
-    buf = getattr(state.regs, buf_reg)
-    count = getattr(state.regs, count_reg)
+    fd = state.syscall_abi.get_arg(state, 0)
+    buf = state.syscall_abi.get_arg(state, 1)
+    count = state.syscall_abi.get_arg(state, 2)
 
     if symbolic(fd) and state.solver.symbolic(fd):
         raise ModelError("linux_read", "symbolic fd not supported")
@@ -37,13 +33,9 @@ def read_handler(state):
 
 
 def write_handler(state):
-    fd_reg = state.os.get_syscall_parameter(1)
-    buf_reg = state.os.get_syscall_parameter(2)
-    count_reg = state.os.get_syscall_parameter(3)
-
-    fd = getattr(state.regs, fd_reg)
-    buf = getattr(state.regs, buf_reg)
-    count = getattr(state.regs, count_reg)
+    fd = state.syscall_abi.get_arg(state, 0)
+    buf = state.syscall_abi.get_arg(state, 1)
+    count = state.syscall_abi.get_arg(state, 2)
 
     if symbolic(fd) and state.solver.symbolic(fd):
         raise ModelError("linux_write", "symbolic fd not supported")

--- a/os_models/linux.py
+++ b/os_models/linux.py
@@ -1,12 +1,11 @@
-from copy import deepcopy
 from ..models import linux_syscalls as models
 from ..expr import Bool
 from .os_file import OsFileHandler
+from ..target.syscall import RegSyscallAbi
 
 
 class Linux(OsFileHandler):
     SYSCALL_TABLE = {}
-    SYSCALL_PARAMS = {}
 
     def __init__(self):
         super().__init__()
@@ -17,10 +16,6 @@ class Linux(OsFileHandler):
         if n not in self.SYSCALL_TABLE:
             return None
         return self.SYSCALL_TABLE[n]
-
-    def get_syscall_parameter(self, k: int):
-        assert 0 < k <= 6
-        return self.SYSCALL_PARAMS[k-1]
 
     def get_stdin_stream(self):
         session = self.descriptors_map[self.stdin_fd]
@@ -43,7 +38,7 @@ class Linux(OsFileHandler):
     def copy_to(self, other):
         super().copy_to(other)
         other.stdin_fd = self.stdin_fd
-        other.stdout_fd = other.stdout_fd
+        other.stdout_fd = self.stdout_fd
 
 
 class Linuxi386(Linux):
@@ -52,15 +47,13 @@ class Linuxi386(Linux):
         3: models.read_handler,
         4: models.write_handler
     }
-    SYSCALL_PARAMS = [
-        "ebx",   "ecx",   "edx",   "esi",   "edi",   "ebp"
-    ]
 
-    def get_syscall_n_reg(self):
-        return "eax"
-
-    def get_out_syscall_reg(self):
-        return "eax"
+    def get_syscall_abi(self, view, arch):
+        return RegSyscallAbi(
+            "eax",
+            ["ebx", "ecx", "edx", "esi", "edi", "ebp"],
+            "eax",
+        )
 
     def copy(self):
         res = Linuxi386()
@@ -78,15 +71,13 @@ class Linuxia64(Linux):
         1: models.write_handler,
         2: None
     }
-    SYSCALL_PARAMS = [
-        "rdi",	"rsi",	"rdx",	"r10",	"r8",	"r9"
-    ]
 
-    def get_syscall_n_reg(self):
-        return "rax"
-
-    def get_out_syscall_reg(self):
-        return "rax"
+    def get_syscall_abi(self, view, arch):
+        return RegSyscallAbi(
+            "rax",
+            ["rdi", "rsi", "rdx", "r10", "r8", "r9"],
+            "rax",
+        )
 
     def copy(self):
         res = Linuxia64()
@@ -104,15 +95,13 @@ class LinuxArmV7(Linux):
         0x900003: models.read_handler,
         0x900004: models.write_handler
     }
-    SYSCALL_PARAMS = [
-        "r0", "r1", "r2", "r3", "r4", "r5", "r6"
-    ]
 
-    def get_syscall_n_reg(self):
-        return "r7"
-
-    def get_out_syscall_reg(self):
-        return "r0"
+    def get_syscall_abi(self, view, arch):
+        return RegSyscallAbi(
+            "r7",
+            ["r0", "r1", "r2", "r3", "r4", "r5", "r6"],
+            "r0",
+        )
 
     def copy(self):
         res = LinuxArmV7()
@@ -130,15 +119,13 @@ class LinuxAArch64(Linux):
         63: models.read_handler,   # sys_read
         64: models.write_handler,  # sys_write
     }
-    SYSCALL_PARAMS = [
-        "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"
-    ]
 
-    def get_syscall_n_reg(self):
-        return "x8"
-
-    def get_out_syscall_reg(self):
-        return "x0"
+    def get_syscall_abi(self, view, arch):
+        return RegSyscallAbi(
+            "x8",
+            ["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"],
+            "x0",
+        )
 
     def copy(self):
         res = LinuxAArch64()

--- a/os_models/macos.py
+++ b/os_models/macos.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from ..expr import Bool
 from .os_file import OsFileHandler
 
@@ -10,15 +9,6 @@ class MacOS(OsFileHandler):
         self.stdout_fd = self.open("__stdout", "-w-")
 
     def get_syscall_by_number(self, n):
-        raise NotImplementedError
-
-    def get_syscall_n_reg(self):
-        raise NotImplementedError
-
-    def get_syscall_parameter(self, k):
-        raise NotImplementedError
-
-    def get_out_syscall_reg(self):
         raise NotImplementedError
 
     def get_stdin_stream(self):

--- a/os_models/null.py
+++ b/os_models/null.py
@@ -2,14 +2,14 @@ from ..expr import Bool
 from .os_file import OsFileHandler
 
 
-class Windows(OsFileHandler):
+class NullOS(OsFileHandler):
     def __init__(self):
         super().__init__()
         self.stdin_fd = self.open("__stdin", "r--")
         self.stdout_fd = self.open("__stdout", "-w-")
 
     def get_syscall_by_number(self, n):
-        raise NotImplementedError
+        return None
 
     def get_stdin_stream(self):
         session = self.descriptors_map[self.stdin_fd]
@@ -17,7 +17,6 @@ class Windows(OsFileHandler):
         session.seek(0)
         res = session.read(session.symfile.file_size)
         session.seek(session_idx)
-
         return res
 
     def get_stdout_stream(self):
@@ -26,14 +25,15 @@ class Windows(OsFileHandler):
         session.seek(0)
         res = session.read(session.symfile.file_size)
         session.seek(session_idx)
-
         return res
 
     def copy(self):
-        res = Windows()
+        res = NullOS()
         super().copy_to(res)
+        res.stdin_fd = self.stdin_fd
+        res.stdout_fd = self.stdout_fd
         return res
 
     def merge(self, other, merge_condition: Bool):
-        assert isinstance(other, Windows)
+        assert isinstance(other, NullOS)
         pass  # TODO implement this

--- a/os_models/os_abstract.py
+++ b/os_models/os_abstract.py
@@ -3,14 +3,8 @@ class Os(object):
     def get_syscall_by_number(self, n):
         raise NotImplementedError
 
-    def get_syscall_n_reg(self):
-        raise NotImplementedError
-
-    def get_syscall_parameter(self, k):
-        raise NotImplementedError
-
-    def get_out_syscall_reg(self):
-        raise NotImplementedError
+    def get_syscall_abi(self, view, arch):
+        return None
     # devices
 
     def open(self, filename, mode):

--- a/target/__init__.py
+++ b/target/__init__.py
@@ -1,0 +1,6 @@
+from .context import TargetContext, resolve_target
+
+__all__ = [
+    "TargetContext",
+    "resolve_target",
+]

--- a/target/abi.py
+++ b/target/abi.py
@@ -1,0 +1,59 @@
+from ..utility.expr_wrap_util import symbolic
+
+
+class CallConvAdapter(object):
+    def __init__(self, calling_convention, arch_adapter=None):
+        self.calling_convention = calling_convention
+        self.arch = arch_adapter
+
+    def arg_reg_names(self):
+        if self.calling_convention is None:
+            return []
+        return list(self.calling_convention.int_arg_regs)
+
+    def return_reg_names(self):
+        if self.calling_convention is None:
+            return []
+        return list(self.calling_convention.int_return_regs)
+
+    def get_arg(self, state, k, size_bytes):
+        arg_regs = self.arg_reg_names()
+        if k - 1 < len(arg_regs):
+            res = getattr(state.regs, arg_regs[k - 1])
+            return res.Extract(size_bytes * 8 - 1, 0)
+
+        stack_pointer = getattr(state.regs, state.arch.get_stack_pointer_reg())
+        assert not symbolic(stack_pointer)
+        offset_words = k - len(arg_regs)
+        return state.mem.load(
+            stack_pointer + (state.arch.bits() // 8) * offset_words,
+            size_bytes,
+            state.arch.endness(),
+        )
+
+    def set_return(self, state, value):
+        regs = self.return_reg_names()
+        if not regs:
+            if self.arch is not None:
+                self.arch.save_result_value(state, self.calling_convention, value)
+            return
+        setattr(state.regs, regs[0], value)
+
+
+class AbiResolver(object):
+    def __init__(self, view, arch_adapter=None):
+        self.view = view
+        self.arch = arch_adapter
+
+    def _default_calling_convention(self):
+        if self.view is None:
+            return None
+        return self.view.platform.default_calling_convention
+
+    def resolve_for_function(self, function):
+        cc = function.calling_convention if function is not None else self._default_calling_convention()
+        return CallConvAdapter(cc, self.arch)
+
+    def get_arg(self, state, function, k, size_bytes):
+        cc = self.resolve_for_function(function)
+        return cc.get_arg(state, k, size_bytes)

--- a/target/arch.py
+++ b/target/arch.py
@@ -1,0 +1,156 @@
+from ..arch.arch_abstract import Arch
+
+
+class BnArchAdapter(Arch):
+    def __init__(self, view):
+        self._view = view
+        self._arch = view.arch
+        self._bits = self._resolve_bits()
+        self._endian = self._resolve_endian()
+        self._regs = self._build_regs()
+        self._reg_names = self._build_reg_names()
+        self._flags = self._build_flags()
+        self._ip = None
+        self._sp = self._normalize_reg_name(self._arch.stack_pointer)
+        self._bp = None
+        self._lr = self._normalize_reg_name(self._arch.link_reg)
+
+    def _normalize_reg_name(self, reg):
+        if reg is None:
+            return None
+        if isinstance(reg, str):
+            return reg
+        return getattr(reg, "name", reg)
+
+    def _resolve_bits(self):
+        return self._arch.address_size * 8
+
+    def _resolve_endian(self):
+        return "little" if self._arch.endianness.name == "LittleEndian" else "big"
+
+    def _iter_reg_infos(self):
+        return self._arch.regs.items()
+
+    def _get_full_reg_name(self, reg_info, reg_name):
+        full = reg_info.full_width_reg
+        if full:
+            return full
+        return reg_name
+
+    def _get_reg_offset(self, reg_info):
+        return reg_info.offset
+
+    def _get_reg_size(self, reg_info):
+        return reg_info.size
+
+    def _build_regs(self):
+        full_regs = {}
+        reg_infos = list(self._iter_reg_infos())
+        for reg_name, reg_info in reg_infos:
+            full_name = self._get_full_reg_name(reg_info, reg_name)
+            if full_name not in full_regs:
+                full_info = self._arch.regs[full_name]
+                size = self._get_reg_size(full_info)
+                full_regs[full_name] = {
+                    "size": size,
+                    "sub": {},
+                }
+
+        for reg_name, reg_info in reg_infos:
+            full_name = self._get_full_reg_name(reg_info, reg_name)
+            if full_name == reg_name:
+                continue
+            parent = full_regs.get(full_name)
+            if not parent:
+                continue
+            parent_size = parent["size"]
+            sub_size = self._get_reg_size(reg_info)
+            bn_offset = self._get_reg_offset(reg_info)
+            mem_offset = max(parent_size - sub_size - bn_offset, 0)
+            parent["sub"][reg_name] = {
+                "offset": mem_offset,
+                "size": sub_size,
+            }
+
+        curr_addr = 0
+        for reg_name in full_regs:
+            reg = full_regs[reg_name]
+            reg["addr"] = curr_addr
+            curr_addr += reg["size"]
+        return full_regs
+
+    def _build_reg_names(self):
+        return list(self._regs.keys())
+
+    def _build_flags(self):
+        names = list(self._arch.flags)
+        return {name: 0 for name in names}
+
+    def bits(self):
+        return self._bits
+
+    def regs_data(self):
+        return self._regs
+
+    def reg_names(self):
+        return self._reg_names
+
+    def flags_data(self):
+        return self._flags
+
+    def flags_default(self, flag):
+        return None
+
+    def endness(self):
+        return self._endian
+
+    def getip_reg(self):
+        if self._ip:
+            return self._ip
+        for name in ("pc", "ip", "rip", "eip"):
+            if name in self._regs:
+                return name
+        return next(iter(self._regs.keys()))
+
+    def get_base_pointer_reg(self):
+        if self._bp:
+            return self._bp
+        for name in ("bp", "rbp", "ebp", "fp"):
+            if name in self._regs:
+                return name
+        return None
+
+    def get_stack_pointer_reg(self):
+        if self._sp:
+            return self._sp
+        for name in ("sp", "rsp", "esp"):
+            if name in self._regs:
+                return name
+        return next(iter(self._regs.keys()))
+
+    def save_return_address(self, state, return_address):
+        if self._lr and self._lr in self._regs:
+            setattr(state.regs, self._lr, return_address)
+            return
+        state.stack_push(return_address)
+
+    def get_return_address(self, state):
+        if self._lr and self._lr in self._regs:
+            return getattr(state.regs, self._lr)
+        return state.stack_pop()
+
+    def get_argument_regs(self, calling_convention):
+        return list(calling_convention.int_arg_regs)
+
+    def save_result_value(self, state, calling_convention, value):
+        reg_names = list(calling_convention.int_return_regs)
+        if not reg_names:
+            return
+        reg = reg_names[0]
+        setattr(state.regs, reg, value)
+
+    def get_flag_cond_lambda(self, cond: str):
+        raise NotImplementedError
+
+    def execute_special_handler(self, disasm_str, sv):
+        return False

--- a/target/context.py
+++ b/target/context.py
@@ -1,0 +1,36 @@
+from .registry import resolve_arch_adapter, resolve_os_model
+from .layout import DataLayout
+from .abi import AbiResolver
+from .syscall import NullSyscallAbi
+from ..os_models.null import NullOS
+
+
+class TargetContext(object):
+    def __init__(self, view, arch, abi, syscall_abi, os_model, layout):
+        self.view = view
+        self.arch = arch
+        self.abi = abi
+        self.syscall_abi = syscall_abi
+        self.os = os_model
+        self.layout = layout
+
+    def clone_with(self, os_model=None):
+        os_model = os_model if os_model is not None else self.os
+        syscall_abi = self.syscall_abi
+        return TargetContext(self.view, self.arch, self.abi, syscall_abi, os_model, self.layout)
+
+
+def resolve_target(view):
+    arch = resolve_arch_adapter(view)
+    os_model = resolve_os_model(view)
+    if os_model is None:
+        os_model = NullOS()
+    layout = DataLayout.from_view(view)
+    abi = AbiResolver(view, arch)
+    syscall_abi = os_model.get_syscall_abi(view, arch)
+
+    if syscall_abi is None:
+        syscall_abi = NullSyscallAbi(
+            "syscall ABI not configured for platform {}".format(view.platform.name)
+        )
+    return TargetContext(view, arch, abi, syscall_abi, os_model, layout)

--- a/target/layout.py
+++ b/target/layout.py
@@ -1,0 +1,22 @@
+class DataLayout(object):
+    def __init__(self, ptr_bits, endian, long_bits=None, size_t_bits=None,
+                 time_t_bits=None, stack_grows_down=True):
+        self.ptr_bits = ptr_bits
+        self.endian = endian
+        self.long_bits = long_bits if long_bits is not None else ptr_bits
+        self.size_t_bits = size_t_bits if size_t_bits is not None else ptr_bits
+        self.time_t_bits = time_t_bits if time_t_bits is not None else ptr_bits
+        self.stack_grows_down = stack_grows_down
+
+    @staticmethod
+    def from_view(view):
+        arch = view.arch
+        ptr_bits = arch.address_size * 8
+        endian = "little" if arch.endianness.name == "LittleEndian" else "big"
+        return DataLayout(ptr_bits, endian)
+
+    @staticmethod
+    def from_arch(arch):
+        ptr_bits = arch.bits()
+        endian = arch.endness()
+        return DataLayout(ptr_bits, endian)

--- a/target/registry.py
+++ b/target/registry.py
@@ -1,0 +1,77 @@
+import inspect
+
+from .arch import BnArchAdapter
+
+_ARCH_FACTORIES = {}
+_OS_FACTORIES = {}
+_BUILTINS_LOADED = False
+
+
+def register_arch_adapter(arch_name, factory):
+    _ARCH_FACTORIES[arch_name] = factory
+
+
+def register_os_model(platform_name, factory):
+    _OS_FACTORIES[platform_name] = factory
+
+
+def _load_builtins():
+    global _BUILTINS_LOADED
+    if _BUILTINS_LOADED:
+        return
+
+    from ..arch.arch_x86 import x86Arch
+    from ..arch.arch_x86_64 import x8664Arch
+    from ..arch.arch_armv7 import ArmV7Arch
+    from ..arch.arch_aarch64 import AArch64Arch
+    from ..os_models.linux import Linuxi386, Linuxia64, LinuxArmV7, LinuxAArch64
+    from ..os_models.windows import Windows
+    from ..os_models.macos import MacOS
+
+    register_arch_adapter("x86", x86Arch)
+    register_arch_adapter("x86_64", x8664Arch)
+    register_arch_adapter("armv7", ArmV7Arch)
+    register_arch_adapter("aarch64", AArch64Arch)
+
+    register_os_model("linux-x86", Linuxi386)
+    register_os_model("linux-x86_64", Linuxia64)
+    register_os_model("linux-armv7", LinuxArmV7)
+    register_os_model("linux-aarch64", LinuxAArch64)
+    register_os_model("windows-x86", Windows)
+    register_os_model("windows-x86_64", Windows)
+    register_os_model("mac-x86_64", MacOS)
+    register_os_model("mac-aarch64", MacOS)
+
+    _BUILTINS_LOADED = True
+
+
+def _instantiate(factory, view):
+    if factory is None:
+        return None
+    if inspect.isclass(factory):
+        sig = inspect.signature(factory)
+        if len(sig.parameters) == 0:
+            return factory()
+        return factory(view)
+    try:
+        return factory(view)
+    except TypeError:
+        return factory()
+
+
+def resolve_arch_adapter(view):
+    _load_builtins()
+    arch_name = view.arch.name
+    factory = _ARCH_FACTORIES.get(arch_name)
+    if factory is None:
+        return BnArchAdapter(view)
+    return _instantiate(factory, view)
+
+
+def resolve_os_model(view):
+    _load_builtins()
+    platform_name = view.platform.name
+    factory = _OS_FACTORIES.get(platform_name)
+    if factory is None:
+        return None
+    return _instantiate(factory, view)

--- a/target/syscall.py
+++ b/target/syscall.py
@@ -1,0 +1,42 @@
+class SyscallAbi(object):
+    def get_number(self, state):
+        raise NotImplementedError
+
+    def get_arg(self, state, idx: int):
+        raise NotImplementedError
+
+    def set_return(self, state, value):
+        raise NotImplementedError
+
+
+class NullSyscallAbi(SyscallAbi):
+    def __init__(self, reason="syscall ABI not configured"):
+        self.reason = reason
+
+    def get_number(self, state):
+        raise NotImplementedError(self.reason)
+
+    def get_arg(self, state, idx: int):
+        raise NotImplementedError(self.reason)
+
+    def set_return(self, state, value):
+        raise NotImplementedError(self.reason)
+
+
+class RegSyscallAbi(SyscallAbi):
+    def __init__(self, number_reg, arg_regs, return_reg):
+        self.number_reg = number_reg
+        self.arg_regs = list(arg_regs)
+        self.return_reg = return_reg
+
+    def get_number(self, state):
+        return getattr(state.regs, self.number_reg)
+
+    def get_arg(self, state, idx: int):
+        if idx >= len(self.arg_regs):
+            raise NotImplementedError("Syscall argument index out of range")
+        return getattr(state.regs, self.arg_regs[idx])
+
+    def set_return(self, state, value):
+        setattr(state.regs, self.return_reg, value)
+

--- a/utility/bninja_util.py
+++ b/utility/bninja_util.py
@@ -1,8 +1,4 @@
 from binaryninja import SymbolType
-from .exceptions import UnsupportedOs
-from ..os_models.linux import Linuxi386, Linuxia64, LinuxArmV7, LinuxAArch64
-from ..os_models.windows import Windows
-from ..os_models.macos import MacOS
 from ..globals import logger
 
 
@@ -74,25 +70,3 @@ def get_address_after_merge(view, address):
     llil = func.llil.get_instruction_start(address, func.arch)
     return func.llil[llil].address
 
-
-def find_os(view):
-    platform_name = view.platform.name
-
-    if platform_name == 'linux-x86_64':
-        return Linuxia64()
-    elif platform_name == 'linux-x86':
-        return Linuxi386()
-    elif platform_name == 'linux-armv7':
-        return LinuxArmV7()
-    elif platform_name == 'linux-aarch64':
-        return LinuxAArch64()
-    elif platform_name == 'windows-x86':
-        return Windows()
-    elif platform_name == 'windows-x86_64':
-        return Windows()
-    elif platform_name == 'mac-aarch64':
-        return MacOS()
-    elif platform_name == 'mac-x86_64':
-        return MacOS()
-
-    raise UnsupportedOs(platform_name)

--- a/utility/models_util.py
+++ b/utility/models_util.py
@@ -1,5 +1,3 @@
-from ..arch.arch_x86 import x86Arch
-from .expr_wrap_util import symbolic
 from .bninja_util import get_function
 
 
@@ -7,14 +5,6 @@ def get_arg_k(state, k, size, view):
 
     ip = state.get_ip()
     func = get_function(view, ip)
-    calling_convention = func.calling_convention.name
-
-    args = state.arch.get_argument_regs(calling_convention)
-    if k-1 < len(args):
-        res = getattr(state.regs, args[k-1])
-        return res.Extract(8*size-1, 0)
-    else:
-        stack_pointer = getattr(state.regs, state.arch.get_stack_pointer_reg())
-        assert not symbolic(stack_pointer)
-
-        return state.mem.load(stack_pointer + (state.arch.bits() // 8)*(k - len(args)), size, state.arch.endness())
+    if not hasattr(state, "abi") or state.abi is None:
+        raise Exception("Missing ABI resolver for argument access")
+    return state.abi.get_arg(state, func, k, size)


### PR DESCRIPTION
this is a refactor to centralize all target resolution and platform specific logic, to make the core as platform agnostic as possible while keeping the existing behavior

this will make it much easier to add support for additional architectures, OSes, etc.

when possible we can also use some hints from binaryninja to provide automatic support for architectures.
for example, it now works automatically on RISCV, thanks to binaryninja's built-in arch support and cross platform of LLIL, even with the null syscall ABI.

tested on Windows, Linux, Mac across arches.